### PR TITLE
实现非管理员token，实现文件前缀

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -52,6 +52,14 @@ export const getConfig = (ctx: PicGo): IPluginConfig[] => {
       required: false,
       alias: '路径前缀',
     },
+    {
+      name: 'filename_prefix',
+      type: 'input',
+      default: userConfig.filename_prefix ?? '',
+      message: 'Alist自动为文件名添加的前缀（如果有），如web',
+      required: false,
+      alias: '文件名前缀',
+    },
   ]
   return config
 }

--- a/src/config.ts
+++ b/src/config.ts
@@ -40,9 +40,17 @@ export const getConfig = (ctx: PicGo): IPluginConfig[] => {
       name: 'token',
       type: 'password',
       default: userConfig.token ?? '',
-      message: '填写管理员token，获取请参考alist文档。',
+      message: '填写用户token，获取请参考alist文档。',
       required: true,
-      alias: '管理员token',
+      alias: '用户token',
+    },
+    {
+      name: 'path_prefix',
+      type: 'input',
+      default: userConfig.path_prefix ?? '',
+      message: '如果使用的不是管理员token，填写下载直链中的路径前缀',
+      required: false,
+      alias: '路径前缀',
     },
   ]
   return config

--- a/src/handler.ts
+++ b/src/handler.ts
@@ -11,9 +11,10 @@ export const handle = async (ctx: PicGo): Promise<PicGo> => {
   const userConfig: UserConfig = ctx.getConfig(bedName)
   if (!userConfig)
     throw new Error("Can't find uploader config")
-  let { url, path, version } = userConfig
+  let { url, path, version, path_prefix } = userConfig
   const { token } = userConfig
   path = rmBothEndSlashes(path)
+  path_prefix = rmBothEndSlashes(path_prefix)
   url = rmEndSlashes(url)
   version = Number(version)
   const imgList = ctx.output
@@ -46,7 +47,7 @@ export const handle = async (ctx: PicGo): Promise<PicGo> => {
         ctx.log.info(`[请求结果]${JSON.stringify(res)}`)
         if (res.code !== Number(200))
           throw new Error(`[请求出错]${JSON.stringify(res)}`)
-        imgList[i].imgUrl = `${url}/d/${path}/${imgList[i].fileName}`
+        imgList[i].imgUrl = `${url}/d${path_prefix ? `/${path_prefix}` : ''}/${path}/${imgList[i].fileName}`
       }
       catch (err) {
         throw new Error(`[上传操作]异常：${err.message}`)

--- a/src/handler.ts
+++ b/src/handler.ts
@@ -47,7 +47,7 @@ export const handle = async (ctx: PicGo): Promise<PicGo> => {
         ctx.log.info(`[请求结果]${JSON.stringify(res)}`)
         if (res.code !== Number(200))
           throw new Error(`[请求出错]${JSON.stringify(res)}`)
-        imgList[i].imgUrl = `${url}/d${path_prefix ? `/${path_prefix}` : ''}/${path}/${imgList[i].fileName}`
+        imgList[i].imgUrl = `${url}/d${path_prefix ? `/${path_prefix}` : ''}/${path}/${(userConfig.filename_prefix || '') + imgList[i].fileName}`
       }
       catch (err) {
         throw new Error(`[上传操作]异常：${err.message}`)

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -5,6 +5,7 @@ export interface UserConfig {
   token: string
   path: string
   path_prefix: string
+  filename_prefix: string
 }
 
 export interface PostOptions {

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -4,6 +4,7 @@ export interface UserConfig {
   url: string
   token: string
   path: string
+  path_prefix: string
 }
 
 export interface PostOptions {


### PR DESCRIPTION
1. 实现非 admin 用户 token 的支持，增加了路径前缀的设置
2. 在我所使用的 3.14 alist 版本中，一刻相册的上传后会自动携带web前缀
