### PR TITLE
✨ feat: 访问路径支持http打头

### DIFF
--- a/src/handler.ts
+++ b/src/handler.ts
@@ -50,7 +50,11 @@ export const handle = async (ctx: PicGo): Promise<PicGo> => {
         ctx.log.info(`[请求结果]${JSON.stringify(res)}`)
         if (res.code !== Number(200))
           throw new Error(`[请求出错]${JSON.stringify(res)}`)
-        imgList[i].imgUrl = `${url}/d/${accessPath}/${imgList[i].fileName}`
+        if(accessPath.startsWith('http')){
+          imgList[i].imgUrl = `${accessPath}/${imgList[i].fileName}`
+        } else {
+          imgList[i].imgUrl = `${url}/d/${accessPath}/${imgList[i].fileName}`
+        }
       }
       catch (err) {
         throw new Error(`[上传操作]异常：${err.message}`)


### PR DESCRIPTION
访问路径允许不使用alist的域名，访问路径配置http:// 或者 https:// 开头时将使用此访问路径直接拼接图片路径